### PR TITLE
Fix markdown formatting

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,4 +1,4 @@
-#Issues
+# Issues
 
 Help us find all bugs in Toxygen! Please provide following info:
 
@@ -9,12 +9,12 @@ Help us find all bugs in Toxygen! Please provide following info:
 
 Want to see new feature in Toxygen? [Ask for it!](https://github.com/toxygen-project/toxygen/issues)
 
-#Pull requests
+# Pull requests
 
 Developer? Feel free to open pull request. Our dev team is small so we glad to get help.
 Don't know what to do? Improve UI, fix [issues](https://github.com/toxygen-project/toxygen/issues) or implement features from our TODO list.
 You can find our TODO's in code, issues list and [here](/README.md). Also you can implement [plugins](/docs/plugins.md) for Toxygen.
 
-#Translations
+# Translations
 
 Help us translate Toxygen! Translation can be created using pyside-lupdate (``pyside-lupdate toxygen.pro``) and QT Linguist.

--- a/docs/smileys_and_stickers.md
+++ b/docs/smileys_and_stickers.md
@@ -1,4 +1,4 @@
-#Smileys
+# Smileys
 
 Toxygen support smileys. Smiley is small picture which replaces some symbol or combination of symbols. If you want to create your own smiley pack, create directory in src/smileys/. This directory must contain images with smileys and config.json. Example of config.json:
 
@@ -6,7 +6,7 @@ Toxygen support smileys. Smiley is small picture which replaces some symbol or c
 
 Animated smileys (.gif) are supported too.
 
-#Stickers
+# Stickers
 
 Sticker is inline image. If you want to create your own smiley pack, create directory in src/stickers/ and place your stickers there.
 


### PR DESCRIPTION
[GitHub changing spec of their Markdown parser](https://github.com/blog/2333-a-formal-spec-for-github-flavored-markdown) broke things that previously worked, e.g. `#Heading` now is displayed as it is and to make it an actual heading one should put a space after `#`, i.e. `# Heading`.